### PR TITLE
Link Typo Fix

### DIFF
--- a/co-morbidities/README.md
+++ b/co-morbidities/README.md
@@ -1,7 +1,7 @@
 # Co-morbidity estimates related to 2019-nCoV
 Location for estimates of potential co-morbid conditions of relevance to 2019-nCoV
 
-Datasets derived from Global Burden of Disease on prevalence rates of known co-morbidities, including Diabetes mellitus. For more information on these estimates please see [metadata](/co-morbities/co-morbidity_metadata.txt)
+Datasets derived from Global Burden of Disease on prevalence rates of known co-morbidities, including Diabetes mellitus. For more information on these estimates please see [metadata](/co-morbidities/co-morbidity_metadata.txt)
 
 ![alt_text](/co-morbidities/graphics/china_diabetes_prevalence_rate_male.png)
 ![alt_text](/co-morbidities/graphics/china_cardiovascular_prevalence_rate_female.png)


### PR DESCRIPTION
Typo in a link, due to a typo in the linked filename being fixed previously.