### PR TITLE
better performance of the dedupe func

### DIFF
--- a/code/sheet_cleaner/functions.py
+++ b/code/sheet_cleaner/functions.py
@@ -181,13 +181,19 @@ def generate_error_tables(data):
 def duplicate_rows_per_column(df: pd.DataFrame, col: str) -> pd.DataFrame:
     """Duplicate rows based on the integer number in 'col' if > 0.
     Changes the data frame in place, returned col will only contain nan."""
+    concats = []
     for i, row in df.iterrows():
         if math.isnan(row[col]) or row[col] <= 0:
             continue
         num = int(row[col])
         row[col] = np.nan
         df.at[i, 'aggr'] = np.nan
-        df = df.append([row] * num, ignore_index=True)
+        # Only append if num is > 1, curators input 1 sometimes.
+        if num > 1:
+            dupes = [row] * (num - 1)
+            concats.extend(dupes)
+    if concats:
+        return df.append(concats, ignore_index=True)
     return df
 
 def trim_df(df: pd.DataFrame) -> pd.DataFrame:

--- a/code/sheet_cleaner/test_functions.py
+++ b/code/sheet_cleaner/test_functions.py
@@ -11,12 +11,32 @@ class TestFunctions(unittest.TestCase):
 
     def test_duplicate_rows(self):
         df = pd.DataFrame(
-            {"country": ["FR", "CH", "US"],
-            "aggr": [np.nan, 3.0, np.nan]})
+            {"country": ["FR", "CH", "US", "JP"],
+            "aggr": [np.nan, 3.0, np.nan, 2.0]})
         dup = duplicate_rows_per_column(df, col="aggr")
         want_df = pd.DataFrame(
-            {"country": ["FR", "CH", "US", "CH", "CH", "CH"],
-            "aggr":[np.nan] * 6})
+            {"country": ["FR", "CH", "US", "JP", "CH", "CH", "JP"],
+            "aggr":[np.nan] * 7})
+        assert_frame_equal(dup, want_df)
+
+    def test_duplicate_rows_one_aggr(self):
+        df = pd.DataFrame(
+            {"country": ["FR", "CH", "US"],
+            "aggr": [np.nan, 1.0, np.nan]})
+        dup = duplicate_rows_per_column(df, col="aggr")
+        want_df = pd.DataFrame(
+            {"country": ["FR", "CH", "US"],
+            "aggr":[np.nan] * 3})
+        assert_frame_equal(dup, want_df)
+    
+    def test_duplicate_rows_empty(self):
+        df = pd.DataFrame(
+            {"country": ["FR", "CH", "US"],
+            "aggr":[np.nan] * 3})
+        dup = duplicate_rows_per_column(df, col="aggr")
+        want_df = pd.DataFrame(
+            {"country": ["FR", "CH", "US"],
+            "aggr":[np.nan] * 3})
         assert_frame_equal(dup, want_df)
 
     def test_trim_df(self):


### PR DESCRIPTION
df.append copies the whole dataframe to return a new one, which means we were previously copying the whole europe data for each aggregate row.

Also fixes an off by one error: do not concatenate rows that had "1" as aggregate number this is useless.

With that change the Europe sheet that was hanging before now finishes in just a few seconds on my machine.