### PR TITLE
Add a workflow to trigger a repository_dispatch event when the case data is updated

### DIFF
--- a/.github/workflows/data-update-dispatch.yml
+++ b/.github/workflows/data-update-dispatch.yml
@@ -1,0 +1,17 @@
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - /latest_data/latestdata.tar.gz
+
+jobs:
+  dispatch-data-update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch case data update repository event
+        run: |
+          curl -X POST https://api.github.com/repos/open-covid-data/healthmap-gdo-temp/dispatches \
+          -H 'Accept: application/vnd.github.everest-preview+json' \
+          -u ${{ secrets.ACCESS_TOKEN }} \
+          --data '{"event_type": "latest-data-push"}'


### PR DESCRIPTION
This allows us to automatically execute the workflow in the `open-covid-data/healthmap-gdo-temp` repo that converts the data to the MongoDB format.

See [the companion PR](https://github.com/open-covid-data/healthmap-gdo-temp/pull/238) in the other repo (the one that listens for the repository_dispatch event)

NOTE: The name of the secret is pending its creation by @tbrewer-healthmap 